### PR TITLE
refactor: use rds IAM policy from postgres manager

### DIFF
--- a/infrastructure/stage/construct/lambda-api/index.ts
+++ b/infrastructure/stage/construct/lambda-api/index.ts
@@ -12,7 +12,7 @@ import {
   OrcaBusApiGateway,
   OrcaBusApiGatewayProps,
 } from '@orcabus/platform-cdk-constructs/api-gateway';
-import { IDatabaseCluster } from 'aws-cdk-lib/aws-rds';
+import { IManagedPolicy } from 'aws-cdk-lib/aws-iam';
 import { EVENT_BUS_NAME } from '@orcabus/platform-cdk-constructs/shared-config/event-bridge';
 import { EventBus } from 'aws-cdk-lib/aws-events';
 import { Secret } from 'aws-cdk-lib/aws-secretsmanager';
@@ -25,13 +25,9 @@ type LambdaProps = {
    */
   basicLambdaConfig: PythonFunctionProps;
   /**
-   * The db cluster to where the lambda authorize to connect
+   * Managed policy granting `rds-db:connect` on the RDS cluster
    */
-  databaseCluster: IDatabaseCluster;
-  /**
-   * The database name that the lambda will use
-   */
-  databaseName: string;
+  rdsConnectPolicy: IManagedPolicy;
   /**
    * The props for api-gateway
    */
@@ -62,7 +58,7 @@ export class LambdaAPIConstruct extends Construct {
       timeout: Duration.seconds(28),
       memorySize: 1024,
     });
-    lambdaProps.databaseCluster.grantConnect(this.lambda, lambdaProps.databaseName);
+    this.lambda.role?.addManagedPolicy(lambdaProps.rdsConnectPolicy);
 
     // allow api lambda to invoke auto-infer case lambda
     this.lambda.addEnvironment(

--- a/infrastructure/stage/construct/lambda-case-finder/index.ts
+++ b/infrastructure/stage/construct/lambda-case-finder/index.ts
@@ -1,6 +1,6 @@
 import { Construct } from 'constructs';
 import { PythonFunction, PythonFunctionProps } from '@aws-cdk/aws-lambda-python-alpha';
-import { IDatabaseCluster } from 'aws-cdk-lib/aws-rds';
+import { IManagedPolicy } from 'aws-cdk-lib/aws-iam';
 import { IVpc } from 'aws-cdk-lib/aws-ec2';
 import { Duration } from 'aws-cdk-lib';
 import { Secret } from 'aws-cdk-lib/aws-secretsmanager';
@@ -11,13 +11,9 @@ type LambdaProps = {
    */
   basicLambdaConfig: PythonFunctionProps;
   /**
-   * The db cluster to where the lambda authorize to connect
+   * Managed policy granting `rds-db:connect` on the RDS cluster
    */
-  databaseCluster: IDatabaseCluster;
-  /**
-   * The database name that the lambda will use
-   */
-  databaseName: string;
+  rdsConnectPolicy: IManagedPolicy;
   /**
    * VPC used for Custom Provider Function
    */
@@ -40,7 +36,7 @@ export class LambdaCaseFinderConstruct extends Construct {
     });
     this.lambda.addEnvironment('ORCABUS_RO_USER_SECRET_ARN', roOrcabusDbCreds.secretArn);
 
-    props.databaseCluster.grantConnect(this.lambda, props.databaseName);
+    this.lambda.role?.addManagedPolicy(props.rdsConnectPolicy);
     roOrcabusDbCreds.grantRead(this.lambda);
   }
 }

--- a/infrastructure/stage/construct/lambda-migration/index.ts
+++ b/infrastructure/stage/construct/lambda-migration/index.ts
@@ -1,7 +1,7 @@
 import { Construct } from 'constructs';
 import { PythonFunction, PythonFunctionProps } from '@aws-cdk/aws-lambda-python-alpha';
 import { InvocationType, Trigger } from 'aws-cdk-lib/triggers';
-import { IDatabaseCluster } from 'aws-cdk-lib/aws-rds';
+import { IManagedPolicy } from 'aws-cdk-lib/aws-iam';
 import { IVpc } from 'aws-cdk-lib/aws-ec2';
 import { Duration } from 'aws-cdk-lib';
 
@@ -11,13 +11,9 @@ type LambdaProps = {
    */
   basicLambdaConfig: PythonFunctionProps;
   /**
-   * The db cluster to where the lambda authorize to connect
+   * Managed policy granting `rds-db:connect` on the RDS cluster
    */
-  databaseCluster: IDatabaseCluster;
-  /**
-   * The database name that the lambda will use
-   */
-  databaseName: string;
+  rdsConnectPolicy: IManagedPolicy;
   /**
    * VPC used for Custom Provider Function
    */
@@ -35,7 +31,7 @@ export class LambdaMigrationConstruct extends Construct {
       handler: 'handler',
       timeout: Duration.minutes(5),
     });
-    props.databaseCluster.grantConnect(migrationLambda, props.databaseName);
+    migrationLambda.role?.addManagedPolicy(props.rdsConnectPolicy);
 
     new Trigger(this, 'MigrationLambdaTrigger', {
       handler: migrationLambda,

--- a/infrastructure/stage/construct/lambda-update-event/index.ts
+++ b/infrastructure/stage/construct/lambda-update-event/index.ts
@@ -1,6 +1,6 @@
 import { Construct } from 'constructs';
 import { PythonFunction, PythonFunctionProps } from '@aws-cdk/aws-lambda-python-alpha';
-import { IDatabaseCluster } from 'aws-cdk-lib/aws-rds';
+import { IManagedPolicy } from 'aws-cdk-lib/aws-iam';
 import { Duration } from 'aws-cdk-lib';
 import { EventBus, Rule } from 'aws-cdk-lib/aws-events';
 import { EVENT_BUS_NAME } from '@orcabus/platform-cdk-constructs/shared-config/event-bridge';
@@ -12,13 +12,9 @@ type LambdaProps = {
    */
   basicLambdaConfig: PythonFunctionProps;
   /**
-   * The db cluster to where the lambda authorize to connect
+   * Managed policy granting `rds-db:connect` on the RDS cluster
    */
-  databaseCluster: IDatabaseCluster;
-  /**
-   * The database name that the lambda will use
-   */
-  databaseName: string;
+  rdsConnectPolicy: IManagedPolicy;
 };
 
 export class LambdaCaseUpdateEvent extends Construct {
@@ -33,7 +29,7 @@ export class LambdaCaseUpdateEvent extends Construct {
       handler: 'handler',
       timeout: Duration.minutes(5),
     });
-    props.databaseCluster.grantConnect(processEventLambda, props.databaseName);
+    processEventLambda.role?.addManagedPolicy(props.rdsConnectPolicy);
 
     orcabusEventBus.grantPutEventsTo(processEventLambda);
     processEventLambda.addEnvironment('EVENT_BUS_NAME', EVENT_BUS_NAME);

--- a/infrastructure/stage/stack.ts
+++ b/infrastructure/stage/stack.ts
@@ -6,12 +6,11 @@ import { Code, Runtime, Architecture, LayerVersion } from 'aws-cdk-lib/aws-lambd
 import { OrcaBusApiGatewayProps } from '@orcabus/platform-cdk-constructs/api-gateway';
 import { LambdaMigrationConstruct } from './construct/lambda-migration';
 import { LambdaAPIConstruct } from './construct/lambda-api';
-import { DatabaseCluster } from 'aws-cdk-lib/aws-rds';
+import { ManagedPolicy } from 'aws-cdk-lib/aws-iam';
 import { StringParameter } from 'aws-cdk-lib/aws-ssm';
 import {
   DB_CLUSTER_ENDPOINT_HOST_PARAMETER_NAME,
-  DB_CLUSTER_IDENTIFIER,
-  DB_CLUSTER_RESOURCE_ID_PARAMETER_NAME,
+  formatRdsPolicyName,
 } from '@orcabus/platform-cdk-constructs/shared-config/database';
 import { EventSchemaConstruct } from './construct/event-schema';
 import { LambdaCaseUpdateEvent } from './construct/lambda-update-event';
@@ -57,19 +56,15 @@ export class CaseManagerStack extends Stack {
       compatibleRuntimes: [Runtime.PYTHON_3_13],
     });
 
-    // Grab the database cluster
-    const clusterResourceIdentifier = StringParameter.valueForStringParameter(
-      this,
-      DB_CLUSTER_RESOURCE_ID_PARAMETER_NAME
-    );
     const clusterHostEndpoint = StringParameter.valueForStringParameter(
       this,
       DB_CLUSTER_ENDPOINT_HOST_PARAMETER_NAME
     );
-    const dbCluster = DatabaseCluster.fromDatabaseClusterAttributes(this, 'OrcabusDbCluster', {
-      clusterIdentifier: DB_CLUSTER_IDENTIFIER,
-      clusterResourceIdentifier: clusterResourceIdentifier,
-    });
+    const rdsConnectPolicy = ManagedPolicy.fromManagedPolicyName(
+      this,
+      'RdsConnectPolicy',
+      formatRdsPolicyName(this.CASE_MANAGER_DB_USER)
+    );
 
     const basicLambdaConfig = {
       entry: path.join(__dirname, '../../case-manager'),
@@ -93,22 +88,19 @@ export class CaseManagerStack extends Stack {
 
     new LambdaMigrationConstruct(this, 'MigrationLambda', {
       basicLambdaConfig: basicLambdaConfig,
-      databaseCluster: dbCluster,
-      databaseName: this.CASE_MANAGER_DB_NAME,
+      rdsConnectPolicy: rdsConnectPolicy,
       vpc: vpc,
     });
 
     const caseFinder = new LambdaCaseFinderConstruct(this, 'CaseFinderLambda', {
       basicLambdaConfig: basicLambdaConfig,
-      databaseCluster: dbCluster,
-      databaseName: this.CASE_MANAGER_DB_NAME,
+      rdsConnectPolicy: rdsConnectPolicy,
       vpc: vpc,
     });
 
     new LambdaAPIConstruct(this, 'APILambda', {
       basicLambdaConfig: basicLambdaConfig,
-      databaseCluster: dbCluster,
-      databaseName: this.CASE_MANAGER_DB_NAME,
+      rdsConnectPolicy: rdsConnectPolicy,
       apiGatewayConstructProps: props.apiGatewayCognitoProps,
       caseAutoInferLambda: caseFinder.lambda,
     });
@@ -117,8 +109,7 @@ export class CaseManagerStack extends Stack {
 
     new LambdaCaseUpdateEvent(this, 'LambdaCaseUpdateEvent', {
       basicLambdaConfig: basicLambdaConfig,
-      databaseCluster: dbCluster,
-      databaseName: this.CASE_MANAGER_DB_NAME,
+      rdsConnectPolicy: rdsConnectPolicy,
     });
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@aws-cdk/aws-lambda-python-alpha": "2.252.0-alpha.0",
-    "@orcabus/platform-cdk-constructs": "1.3.0",
+    "@orcabus/platform-cdk-constructs": "1.4.0",
     "aws-cdk-lib": "^2.252.0",
     "case-manager": "link:",
     "constructs": "^10.6.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: 2.252.0-alpha.0
         version: 2.252.0-alpha.0(aws-cdk-lib@2.252.0(constructs@10.6.0))(constructs@10.6.0)
       '@orcabus/platform-cdk-constructs':
-        specifier: 1.3.0
-        version: 1.3.0(@aws-cdk/aws-lambda-python-alpha@2.252.0-alpha.0(aws-cdk-lib@2.252.0(constructs@10.6.0))(constructs@10.6.0))(aws-cdk-lib@2.252.0(constructs@10.6.0))(constructs@10.6.0)
+        specifier: 1.4.0
+        version: 1.4.0(@aws-cdk/aws-lambda-python-alpha@2.252.0-alpha.0(aws-cdk-lib@2.252.0(constructs@10.6.0))(constructs@10.6.0))(aws-cdk-lib@2.252.0(constructs@10.6.0))(constructs@10.6.0)
       aws-cdk-lib:
         specifier: ^2.252.0
         version: 2.252.0(constructs@10.6.0)
@@ -442,8 +442,8 @@ packages:
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
-  '@orcabus/platform-cdk-constructs@1.3.0':
-    resolution: {integrity: sha512-/tZHE0Dy6gWW4PiUZcCOW/pcIYD7EI82H8HdCdV9YIeHmkkaxxzBVdv6m49wevTEdhF5ESgL+O26rH69SowX9w==}
+  '@orcabus/platform-cdk-constructs@1.4.0':
+    resolution: {integrity: sha512-rMJh1ZH9HoYJJvlyOjogEn4XyS97bFR1Ta6grp0Sk2WOwDxX0Rn47Bh4uYUjRrLjjS6CX2C/PM4pvO6lEMfFrQ==}
     peerDependencies:
       '@aws-cdk/aws-lambda-python-alpha': ^2.244.0-alpha.0
       aws-cdk-lib: ^2.244.0
@@ -2314,7 +2314,7 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@orcabus/platform-cdk-constructs@1.3.0(@aws-cdk/aws-lambda-python-alpha@2.252.0-alpha.0(aws-cdk-lib@2.252.0(constructs@10.6.0))(constructs@10.6.0))(aws-cdk-lib@2.252.0(constructs@10.6.0))(constructs@10.6.0)':
+  '@orcabus/platform-cdk-constructs@1.4.0(@aws-cdk/aws-lambda-python-alpha@2.252.0-alpha.0(aws-cdk-lib@2.252.0(constructs@10.6.0))(constructs@10.6.0))(aws-cdk-lib@2.252.0(constructs@10.6.0))(constructs@10.6.0)':
     dependencies:
       '@aws-cdk/aws-lambda-python-alpha': 2.252.0-alpha.0(aws-cdk-lib@2.252.0(constructs@10.6.0))(constructs@10.6.0)
       aws-cdk-lib: 2.252.0(constructs@10.6.0)


### PR DESCRIPTION
Closes https://github.com/OrcaBus/wiki/issues/74

See related https://github.com/OrcaBus/wiki/issues/72

This updates the role to use the postgres manager RDS iam policy.