### PR TITLE
Feat: add queue for library-case link

### DIFF
--- a/case-manager/app/tests/test_handler_metadata_manager_linking.py
+++ b/case-manager/app/tests/test_handler_metadata_manager_linking.py
@@ -4,8 +4,10 @@ import os
 from unittest.mock import patch, MagicMock
 
 # Must be set before handler module is imported (module-level code runs on import)
-os.environ.setdefault("METADATA_MANAGER_LINKING_QUEUE_URL",
-                      "https://sqs.ap-southeast-2.amazonaws.com/123456789/test-queue")
+os.environ.setdefault(
+    "METADATA_MANAGER_LINKING_QUEUE_URL",
+    "https://sqs.ap-southeast-2.amazonaws.com/123456789/test-queue",
+)
 os.environ.setdefault("AWS_DEFAULT_REGION", "ap-southeast-2")
 os.environ.setdefault("AWS_ACCESS_KEY_ID", "testing")
 os.environ.setdefault("AWS_SECRET_ACCESS_KEY", "testing")
@@ -88,7 +90,10 @@ class MetadataManagerLinkingHandlerTest(TestCase):
     # ------------------------------------------------------------------
 
     def test_case_not_found_extends_visibility_and_raises(self, mock_sqs):
-        from handler.metadata_manager_linking import handler, VISIBILITY_TIMEOUT_RETRY_SECONDS
+        from handler.metadata_manager_linking import (
+            handler,
+            VISIBILITY_TIMEOUT_RETRY_SECONDS,
+        )
 
         data = {**VALID_DATA, "requestFormId": "nonexistent-form-id"}
 
@@ -120,7 +125,9 @@ class MetadataManagerLinkingHandlerTest(TestCase):
     def test_malformed_body_skips_silently(self, mock_sqs):
         from handler.metadata_manager_linking import handler
 
-        event = {"Records": [{"messageId": "bad", "receiptHandle": "h", "body": "NOT JSON"}]}
+        event = {
+            "Records": [{"messageId": "bad", "receiptHandle": "h", "body": "NOT JSON"}]
+        }
         handler(event, {})  # should not raise
 
     # ------------------------------------------------------------------
@@ -130,10 +137,12 @@ class MetadataManagerLinkingHandlerTest(TestCase):
     def test_multiple_records_raises(self, mock_sqs):
         from handler.metadata_manager_linking import handler
 
-        event = {"Records": [
-            {"messageId": "a", "receiptHandle": "h1", "body": "{}"},
-            {"messageId": "b", "receiptHandle": "h2", "body": "{}"},
-        ]}
+        event = {
+            "Records": [
+                {"messageId": "a", "receiptHandle": "h1", "body": "{}"},
+                {"messageId": "b", "receiptHandle": "h2", "body": "{}"},
+            ]
+        }
         with self.assertRaises(ValueError):
             handler(event, {})
 

--- a/case-manager/app/tests/test_handler_metadata_manager_linking.py
+++ b/case-manager/app/tests/test_handler_metadata_manager_linking.py
@@ -1,0 +1,151 @@
+import json
+import logging
+import os
+from unittest.mock import patch, MagicMock
+
+# Must be set before handler module is imported (module-level code runs on import)
+os.environ.setdefault("METADATA_MANAGER_LINKING_QUEUE_URL",
+                      "https://sqs.ap-southeast-2.amazonaws.com/123456789/test-queue")
+os.environ.setdefault("AWS_DEFAULT_REGION", "ap-southeast-2")
+os.environ.setdefault("AWS_ACCESS_KEY_ID", "testing")
+os.environ.setdefault("AWS_SECRET_ACCESS_KEY", "testing")
+
+from django.core.exceptions import ObjectDoesNotExist
+from django.test import TestCase
+
+from app.tests.factories import CaseFactory, CASE_REQUEST_FORM_ID_001
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+def make_sqs_event(detail_data: dict, message_id: str = "msg-001") -> dict:
+    body = {"detail": {"data": detail_data}}
+    return {
+        "Records": [
+            {
+                "messageId": message_id,
+                "receiptHandle": "fake-receipt-handle",
+                "body": json.dumps(body),
+            }
+        ]
+    }
+
+
+VALID_DATA = {
+    "orcabusId": "lib.ABC123",
+    "requestFormId": CASE_REQUEST_FORM_ID_001,
+}
+
+
+# Patch the sqs client *object* on the already-imported module, not boto3.client itself.
+# This works because by test time the module is loaded and `sqs` is a module-level name.
+@patch("handler.metadata_manager_linking.sqs")
+class MetadataManagerLinkingHandlerTest(TestCase):
+    """
+    python manage.py test app.tests.test_handler_metadata_manager_linking
+    """
+
+    def setUp(self):
+        self.case = CaseFactory(request_form_id=CASE_REQUEST_FORM_ID_001)
+
+    # ------------------------------------------------------------------
+    # Happy path
+    # ------------------------------------------------------------------
+
+    @patch("handler.metadata_manager_linking.get_or_create_external_entity")
+    @patch("handler.metadata_manager_linking.link_case_to_external_entity_and_emit")
+    def test_success_links_case(self, mock_link, mock_get_entity, mock_sqs):
+        from handler.metadata_manager_linking import handler
+
+        mock_get_entity.return_value = MagicMock()
+        mock_link.return_value = MagicMock()
+
+        handler(make_sqs_event(VALID_DATA), {})
+
+        mock_get_entity.assert_called_once_with("lib.ABC123")
+        mock_link.assert_called_once()
+        mock_sqs.change_message_visibility.assert_not_called()
+
+    # ------------------------------------------------------------------
+    # Idempotency
+    # ------------------------------------------------------------------
+
+    @patch("handler.metadata_manager_linking.get_or_create_external_entity")
+    @patch("handler.metadata_manager_linking.link_case_to_external_entity_and_emit")
+    def test_already_linked_is_silent(self, mock_link, mock_get_entity, mock_sqs):
+        from django.db import IntegrityError
+        from handler.metadata_manager_linking import handler
+
+        mock_get_entity.return_value = MagicMock()
+        mock_link.side_effect = IntegrityError("duplicate key")
+
+        handler(make_sqs_event(VALID_DATA), {})  # should NOT raise
+        mock_sqs.change_message_visibility.assert_not_called()
+
+    # ------------------------------------------------------------------
+    # Case not found yet → extend visibility and re-raise
+    # ------------------------------------------------------------------
+
+    def test_case_not_found_extends_visibility_and_raises(self, mock_sqs):
+        from handler.metadata_manager_linking import handler, VISIBILITY_TIMEOUT_RETRY_SECONDS
+
+        data = {**VALID_DATA, "requestFormId": "nonexistent-form-id"}
+
+        with self.assertRaises(ObjectDoesNotExist):
+            handler(make_sqs_event(data), {})
+
+        mock_sqs.change_message_visibility.assert_called_once_with(
+            QueueUrl="https://sqs.ap-southeast-2.amazonaws.com/123456789/test-queue",
+            ReceiptHandle="fake-receipt-handle",
+            VisibilityTimeout=VISIBILITY_TIMEOUT_RETRY_SECONDS,
+        )
+
+    # ------------------------------------------------------------------
+    # Invalid / skipped messages
+    # ------------------------------------------------------------------
+
+    def test_missing_orcabus_id_skips_silently(self, mock_sqs):
+        from handler.metadata_manager_linking import handler
+
+        handler(make_sqs_event({"requestFormId": CASE_REQUEST_FORM_ID_001}), {})
+        mock_sqs.change_message_visibility.assert_not_called()
+
+    def test_nan_request_form_id_skips_silently(self, mock_sqs):
+        from handler.metadata_manager_linking import handler
+
+        handler(make_sqs_event({"orcabusId": "lib.ABC123", "requestFormId": "nan"}), {})
+        mock_sqs.change_message_visibility.assert_not_called()
+
+    def test_malformed_body_skips_silently(self, mock_sqs):
+        from handler.metadata_manager_linking import handler
+
+        event = {"Records": [{"messageId": "bad", "receiptHandle": "h", "body": "NOT JSON"}]}
+        handler(event, {})  # should not raise
+
+    # ------------------------------------------------------------------
+    # Guard: wrong batch size
+    # ------------------------------------------------------------------
+
+    def test_multiple_records_raises(self, mock_sqs):
+        from handler.metadata_manager_linking import handler
+
+        event = {"Records": [
+            {"messageId": "a", "receiptHandle": "h1", "body": "{}"},
+            {"messageId": "b", "receiptHandle": "h2", "body": "{}"},
+        ]}
+        with self.assertRaises(ValueError):
+            handler(event, {})
+
+    # ------------------------------------------------------------------
+    # Unexpected error re-raises
+    # ------------------------------------------------------------------
+
+    @patch("handler.metadata_manager_linking.get_or_create_external_entity")
+    def test_unexpected_error_reraises(self, mock_get_entity, mock_sqs):
+        from handler.metadata_manager_linking import handler
+
+        mock_get_entity.side_effect = RuntimeError("something went wrong")
+
+        with self.assertRaises(RuntimeError):
+            handler(make_sqs_event(VALID_DATA), {})

--- a/case-manager/handler/metadata_manager_linking.py
+++ b/case-manager/handler/metadata_manager_linking.py
@@ -41,7 +41,9 @@ def process_record(body: dict) -> None:
         )
         return
 
-    case = Case.objects.get(request_form_id=request_form_id)  # raises ObjectDoesNotExist
+    case = Case.objects.get(
+        request_form_id=request_form_id
+    )  # raises ObjectDoesNotExist
 
     external_entity = get_or_create_external_entity(library_orcabus_id)
 
@@ -49,7 +51,9 @@ def process_record(body: dict) -> None:
         link = link_case_to_external_entity_and_emit(
             case, external_entity, history_user="system"
         )
-        logger.info(f"Successfully linked '{library_orcabus_id}' to case '{case.orcabus_id}'")
+        logger.info(
+            f"Successfully linked '{library_orcabus_id}' to case '{case.orcabus_id}'"
+        )
         logger.info(f"Link data: {CaseExternalEntityLinkCreateSerializer(link).data}")
     except IntegrityError:
         logger.warning(

--- a/case-manager/handler/metadata_manager_linking.py
+++ b/case-manager/handler/metadata_manager_linking.py
@@ -18,7 +18,7 @@ from app.serializers.case import CaseExternalEntityLinkCreateSerializer
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
-QUEUE_URL = os.environ["METADATA_MANAGER_LINKING_QUEUE_URL"]
+QUEUE_URL = os.environ.get("METADATA_MANAGER_LINKING_QUEUE_URL")
 # SQS enforces a hard 43200s (12h) ceiling on total visibility timeout measured from
 # first receipt, not from the ChangeMessageVisibility call. Subtracting the Lambda
 # timeout (15 min = 900s) ensures we never breach the limit regardless of when during
@@ -68,8 +68,8 @@ def handler(event, context):
     Flow:
     - EventBridge delivers MetadataStateChange events → SQS queue → this Lambda.
     - Success / already linked / invalid message: returns normally → SQS auto-deletes.
-    - ObjectDoesNotExist (case not ready yet): extends visibility to 12h then raises →
-      SQS keeps the message and redelivers after 12h. After 4 attempts → DLQ.
+    - ObjectDoesNotExist (case not ready yet): extends visibility to ~11h45m then raises →
+        SQS keeps the message and redelivers later. After maxReceiveCount failures → DLQ.
     - Unexpected errors: raises → SQS retries via default policy, then DLQ.
     """
     records = event.get("Records", [])
@@ -101,8 +101,13 @@ def handler(event, context):
 
         except ObjectDoesNotExist:
             logger.warning(
-                f"[{message_id}] Case not found yet — extending visibility to 12h for retry"
+                f"[{message_id}] Case not found yet — extending visibility to {VISIBILITY_TIMEOUT_RETRY_SECONDS}s for "
+                f"retry"
             )
+            if not QUEUE_URL:
+                raise RuntimeError(
+                    "METADATA_MANAGER_LINKING_QUEUE_URL environment variable is not set"
+                )
             sqs.change_message_visibility(
                 QueueUrl=QUEUE_URL,
                 ReceiptHandle=receipt_handle,

--- a/case-manager/handler/metadata_manager_linking.py
+++ b/case-manager/handler/metadata_manager_linking.py
@@ -1,6 +1,8 @@
 import os
+import json
 import logging
 import django
+import boto3
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "app.settings.base")
 django.setup()
@@ -16,42 +18,94 @@ from app.serializers.case import CaseExternalEntityLinkCreateSerializer
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
+QUEUE_URL = os.environ["METADATA_MANAGER_LINKING_QUEUE_URL"]
+# SQS enforces a hard 43200s (12h) ceiling on total visibility timeout measured from
+# first receipt, not from the ChangeMessageVisibility call. Subtracting the Lambda
+# timeout (15 min = 900s) ensures we never breach the limit regardless of when during
+# execution the call is made.
+VISIBILITY_TIMEOUT_RETRY_SECONDS = 12 * 60 * 60 - 15 * 60  # ~11h 45m
 
-def handler(event, context):
-    """Lambda handler that links a metadata library entity to a case via EventBridge event."""
-    logger.info(f"Processing event: {event}")
+sqs = boto3.client("sqs")
 
-    detail = event.get("detail", {})
-    data = detail.get("data", {})
+
+def process_record(body: dict) -> None:
+    """Process a single SQS message body (EventBridge event envelope)."""
+    data = body.get("detail", {}).get("data", {})
 
     library_orcabus_id = data.get("orcabusId")
     request_form_id = data.get("requestFormId")
 
     if not library_orcabus_id or not request_form_id or request_form_id == "nan":
         logger.warning(
-            f"Skipping event: no valid 'orcabusId' or 'requestFormId' in data: {data}"
+            f"Skipping message: no valid 'orcabusId' or 'requestFormId' in data: {data}"
         )
         return
 
-    try:
-        case = Case.objects.get(request_form_id=request_form_id)
-    except ObjectDoesNotExist:
-        logger.error(f"No case found for request_form_id: {request_form_id}")
-        raise
+    case = Case.objects.get(request_form_id=request_form_id)  # raises ObjectDoesNotExist
 
     external_entity = get_or_create_external_entity(library_orcabus_id)
 
     try:
-
         link = link_case_to_external_entity_and_emit(
             case, external_entity, history_user="system"
         )
-        logger.info(
-            f"Successfully linked '{library_orcabus_id}' to case '{case.orcabus_id}'"
-        )
+        logger.info(f"Successfully linked '{library_orcabus_id}' to case '{case.orcabus_id}'")
         logger.info(f"Link data: {CaseExternalEntityLinkCreateSerializer(link).data}")
-
     except IntegrityError:
         logger.warning(
             f"Library '{library_orcabus_id}' is already linked to case '{case.orcabus_id}', skipping."
         )
+
+
+def handler(event, context):
+    """
+    Lambda handler invoked by SQS event source mapping (batchSize=1).
+
+    Flow:
+    - EventBridge delivers MetadataStateChange events → SQS queue → this Lambda.
+    - Success / already linked / invalid message: returns normally → SQS auto-deletes.
+    - ObjectDoesNotExist (case not ready yet): extends visibility to 12h then raises →
+      SQS keeps the message and redelivers after 12h. After 4 attempts → DLQ.
+    - Unexpected errors: raises → SQS retries via default policy, then DLQ.
+    """
+    records = event.get("Records", [])
+    logger.info(f"Received {len(records)} SQS record(s)")
+
+    if len(records) != 1:
+        raise ValueError(
+            f"Expected exactly 1 SQS record (batchSize=1 is required), got {len(records)}. "
+            "Check the SQS event source mapping configuration."
+        )
+
+    for record in records:
+        receipt_handle = record["receiptHandle"]
+        message_id = record.get("messageId", "unknown")
+
+        logger.info(
+            f"[{message_id}] Processing SQS record: {json.dumps(record, default=str)}"
+        )
+
+        try:
+            body = json.loads(record["body"])
+        except (json.JSONDecodeError, KeyError) as e:
+            logger.error(f"[{message_id}] Malformed message body, skipping: {e}")
+            continue
+
+        try:
+            process_record(body)
+            logger.info(f"[{message_id}] Successfully processed")
+
+        except ObjectDoesNotExist:
+            logger.warning(
+                f"[{message_id}] Case not found yet — extending visibility to 12h for retry"
+            )
+            sqs.change_message_visibility(
+                QueueUrl=QUEUE_URL,
+                ReceiptHandle=receipt_handle,
+                VisibilityTimeout=VISIBILITY_TIMEOUT_RETRY_SECONDS,
+            )
+            raise  # Prevents SQS from auto-deleting; message reappears after 12h.
+
+        except Exception as e:
+            logger.error(f"[{message_id}] Unexpected error: {e}")
+            raise

--- a/infrastructure/stage/construct/lambda-metadata-linking/index.ts
+++ b/infrastructure/stage/construct/lambda-metadata-linking/index.ts
@@ -3,12 +3,14 @@ import { PythonFunction, PythonFunctionProps } from '@aws-cdk/aws-lambda-python-
 import { Duration } from 'aws-cdk-lib';
 import { ManagedPolicy } from 'aws-cdk-lib/aws-iam';
 import { formatRdsPolicyName } from '@orcabus/platform-cdk-constructs/shared-config/database';
-import { LambdaFunction } from 'aws-cdk-lib/aws-events-targets';
+import { SqsQueue } from 'aws-cdk-lib/aws-events-targets';
 import { EventBus, Rule } from 'aws-cdk-lib/aws-events';
 import { EVENT_BUS_NAME } from '@orcabus/platform-cdk-constructs/shared-config/event-bridge';
 import { Secret } from 'aws-cdk-lib/aws-secretsmanager';
 import { JWT_SECRET_NAME } from '@orcabus/platform-cdk-constructs/shared-config/secrets';
 import { StringParameter } from 'aws-cdk-lib/aws-ssm';
+import { Queue, QueueEncryption } from 'aws-cdk-lib/aws-sqs';
+import { SqsEventSource } from 'aws-cdk-lib/aws-lambda-event-sources';
 
 type MetadataEntityLinkLambdaProps = {
   /**
@@ -57,17 +59,49 @@ export class LambdaMetadataEntityLinkConstruct extends Construct {
     orcabusEventBus.grantPutEventsTo(this.lambda);
     this.lambda.addEnvironment('EVENT_BUS_NAME', EVENT_BUS_NAME);
 
-    // Add EventBridge rule to trigger Lambda on MetadataStateChange events from orcabus.metadatamanager
-    const metadataLinkLambdaEventTarget = new LambdaFunction(this.lambda);
-    new Rule(this, 'MetadataEntityLinkLambdaRule', {
+    // Dead-letter queue: receives messages that fail after maxReceiveCount attempts
+    const metadataLinkDlq = new Queue(this, 'MetadataEntityLinkDlq', {
+      queueName: 'CaseManagerMetadataEntityLinkDlq',
+      encryption: QueueEncryption.SQS_MANAGED,
+      retentionPeriod: Duration.days(14),
+    });
+
+    // Main queue: EventBridge delivers events here; Lambda polls via event source mapping.
+    // visibilityTimeout must be >= Lambda timeout (15 min) to prevent redelivery mid-execution.
+    const metadataLinkQueue = new Queue(this, 'MetadataEntityLinkQueue', {
+      queueName: 'CaseManagerMetadataEntityLinkQueue',
+      encryption: QueueEncryption.SQS_MANAGED,
+      visibilityTimeout: Duration.minutes(15),
+      retentionPeriod: Duration.days(14),
+      deadLetterQueue: {
+        queue: metadataLinkDlq,
+        // On ObjectDoesNotExist the Lambda extends visibility to ~11h 45min then raises,
+        // so 3 attempts = at least 24 hour retries before giving up (daily REDCap should already sync at least once).
+        maxReceiveCount: 3,
+      },
+    });
+
+    // Grant Lambda permission to extend message visibility (used for 12h retry on case-not-found)
+    metadataLinkQueue.grantConsumeMessages(this.lambda);
+    this.lambda.addEnvironment('METADATA_MANAGER_LINKING_QUEUE_URL', metadataLinkQueue.queueUrl);
+
+    // Event source mapping: SQS invokes Lambda per message (batchSize=1 for independent processing)
+    this.lambda.addEventSource(
+      new SqsEventSource(metadataLinkQueue, {
+        batchSize: 1,
+      })
+    );
+
+    // EventBridge rule: deliver MetadataStateChange events into SQS
+    new Rule(this, 'MetadataEntityLinkEventRule', {
       eventBus: orcabusEventBus,
       description:
-        'Rule to trigger Lambda on MetadataStateChange events from orcabus.metadatamanager to link with cases',
+        'Deliver MetadataStateChange events from orcabus.metadatamanager into SQS for Lambda processing',
       eventPattern: {
         source: ['orcabus.metadatamanager'],
         detailType: ['MetadataStateChange'],
       },
-      targets: [metadataLinkLambdaEventTarget],
+      targets: [new SqsQueue(metadataLinkQueue)],
     });
   }
 }

--- a/infrastructure/stage/construct/lambda-metadata-linking/index.ts
+++ b/infrastructure/stage/construct/lambda-metadata-linking/index.ts
@@ -63,6 +63,7 @@ export class LambdaMetadataEntityLinkConstruct extends Construct {
     const metadataLinkDlq = new Queue(this, 'MetadataEntityLinkDlq', {
       queueName: 'CaseManagerMetadataEntityLinkDlq',
       encryption: QueueEncryption.SQS_MANAGED,
+      enforceSSL: true,
       retentionPeriod: Duration.days(14),
     });
 
@@ -71,6 +72,7 @@ export class LambdaMetadataEntityLinkConstruct extends Construct {
     const metadataLinkQueue = new Queue(this, 'MetadataEntityLinkQueue', {
       queueName: 'CaseManagerMetadataEntityLinkQueue',
       encryption: QueueEncryption.SQS_MANAGED,
+      enforceSSL: true,
       visibilityTimeout: Duration.minutes(15),
       retentionPeriod: Duration.days(14),
       deadLetterQueue: {


### PR DESCRIPTION
Add a queue to anticipate whether metadata is linked to a case ID that has not yet existed. The queue will keep retrying for the next 24 hours (as the REDCap sync is triggered daily) before sending to the DLQ.