### PR TITLE
Fix: Alter WorkflowRun Case Linking Event Pattern

### DIFF
--- a/infrastructure/stage/construct/lambda-workflow-run-linking/index.ts
+++ b/infrastructure/stage/construct/lambda-workflow-run-linking/index.ts
@@ -65,7 +65,7 @@ export class LambdaWorkflowRunEntityLinkConstruct extends Construct {
       eventPattern: {
         detailType: ['WorkflowRunStateChange'],
         detail: {
-          status: ['DRAFT'],
+          status: ['READY'],
         },
       },
       targets: [workflowRunLinkLambdaEventTarget],


### PR DESCRIPTION
A workflow run record can go to READY without the DRAFT (e.g. rnasum rerun), so switching to catch the `READY` event instead.