### PR TITLE
feat: workflow_run and sequence_run linking

### DIFF
--- a/case-manager/app/serializers/case.py
+++ b/case-manager/app/serializers/case.py
@@ -84,6 +84,12 @@ class CaseExternalEntityLinkCreateSerializer(ModelSerializer):
         fields = "__all__"
 
 
+class CaseSequenceRunLinkCreateSerializer(Serializer):
+    sequence_run_id = CharField(
+        help_text="The sequenceRunId (alias) of the sequence run to link, e.g. 'r.uY6hEBUmv5x5XUDhkNVxtY'."
+    )
+
+
 class CaseUserCreateSerializer(ModelSerializer):
     case = CharField(read_only=True)
     email = EmailField(write_only=True)

--- a/case-manager/app/service/external_entity.py
+++ b/case-manager/app/service/external_entity.py
@@ -14,7 +14,7 @@ def fetch_external_entity_data(orcabus_id: str):
     Query the metadata and/or workflow service to get entity details.
 
     Supports:
-    - Prefixed IDs: wfr.* (workflow), lib.* (library)
+    - Prefixed IDs: wfr.* (workflow), lib.* (library), seq.* (sequence)
     - Unprefixed IDs: tries workflow first, then metadata
 
     Returns:
@@ -40,6 +40,13 @@ def fetch_external_entity_data(orcabus_id: str):
         services = [
             ("metadata", f"https://metadata.{domain_name}/api/v1/library/{orcabus_id}")
         ]
+    elif orcabus_id.startswith("seq."):
+        services = [
+            (
+                "sequence",
+                f"https://sequence.{domain_name}/api/v1/sequence_run/{orcabus_id}/",
+            )
+        ]
     else:
         # No prefix: try both services (workflow first)
         services = [
@@ -48,6 +55,10 @@ def fetch_external_entity_data(orcabus_id: str):
                 f"https://workflow.{domain_name}/api/v1/workflowrun/{orcabus_id}",
             ),
             ("metadata", f"https://metadata.{domain_name}/api/v1/library/{orcabus_id}"),
+            (
+                "sequence",
+                f"https://sequence.{domain_name}/api/v1/sequence_run/{orcabus_id}/",
+            ),
         ]
 
     # Try each service
@@ -97,7 +108,7 @@ def get_or_create_sequence_run_entity(sequence_run_id: str) -> ExternalEntity:
     jwt_token = get_service_jwt()
     headers = {"Authorization": f"Bearer {jwt_token}"}
     domain_name = os.environ["HOSTED_ZONE_NAME"]
-    url = f"https://sequence.{domain_name}/api/v1/sequencerun/"
+    url = f"https://sequence.{domain_name}/api/v1/sequence_run/"
 
     try:
         response = requests.get(
@@ -145,8 +156,9 @@ def get_or_create_external_entity(external_entity_orcabus_id: str) -> ExternalEn
     Get or create external entity by orcabus_id.
 
     Creates the entity by looking it up in the appropriate service based on the orcabus_id prefix:
-      prefix wfr. -> workflow run (workflow service)
+      prefix wfr. -> workflow_run run (workflow service)
       prefix lib. -> library (metadata service)
+      prefix seq. -> sequence_run (sequence service)
 
     For sequence runs, use get_or_create_sequence_run_entity() instead.
     """
@@ -177,6 +189,18 @@ def get_or_create_external_entity(external_entity_orcabus_id: str) -> ExternalEn
                 type="library",
                 service_name="metadata",
                 alias=entity_data.get("libraryId"),
+            )
+            logger.info(
+                f"Created library external entity: {external_entity_orcabus_id}"
+            )
+            return external_entity
+        elif service == "sequence":
+            external_entity = ExternalEntity.objects.create(
+                orcabus_id=external_entity_orcabus_id,
+                prefix="seq",
+                type="sequence_run",
+                service_name="sequence",
+                alias=entity_data.get("sequenceRunId"),
             )
             logger.info(
                 f"Created library external entity: {external_entity_orcabus_id}"

--- a/case-manager/app/service/external_entity.py
+++ b/case-manager/app/service/external_entity.py
@@ -70,15 +70,85 @@ def fetch_external_entity_data(orcabus_id: str):
     raise Http404(f"No ExternalEntity matches the given orcabus_id: {orcabus_id}")
 
 
+def get_or_create_sequence_run_entity(sequence_run_id: str) -> ExternalEntity:
+    """
+    Get or create an ExternalEntity for a sequence run identified by its sequenceRunId.
+
+    The sequenceRunId from the event payload is NOT the orcabus_id. This function
+    queries the sequence service to resolve the real orcabusId, then gets or creates
+    the corresponding ExternalEntity.
+
+    Args:
+        sequence_run_id: The sequenceRunId from the event (e.g. "r.uY6hEBUmv5x5XUDhkNVxtY").
+
+    Returns:
+        The existing or newly created ExternalEntity for the sequence run.
+
+    Raises:
+        Http404: When the sequence run is not found in the sequence service.
+    """
+    # Fast path: entity already exists (keyed by alias + type)
+    try:
+        return ExternalEntity.objects.get(alias=sequence_run_id, type="sequence_run")
+    except ObjectDoesNotExist:
+        pass
+
+    # Query the sequence service to resolve the real orcabusId
+    jwt_token = get_service_jwt()
+    headers = {"Authorization": f"Bearer {jwt_token}"}
+    domain_name = os.environ["HOSTED_ZONE_NAME"]
+    url = f"https://sequence.{domain_name}/api/v1/sequencerun/"
+
+    try:
+        response = requests.get(
+            url, headers=headers, params={"sequenceRunId": sequence_run_id}
+        )
+    except requests.RequestException as e:
+        logger.error(
+            f"Sequence service request failed for sequenceRunId '{sequence_run_id}': {e}"
+        )
+        raise Http404(
+            f"Sequence service unreachable for sequenceRunId: {sequence_run_id}"
+        )
+
+    if response.status_code != 200:
+        raise Http404(
+            f"Sequence service returned {response.status_code} for sequenceRunId '{sequence_run_id}'"
+        )
+
+    data = response.json()
+    results = data.get("results")
+    if not results or len(results) != 1:
+        raise Http404(
+            f"Sequence run is not equal to one for sequenceRunId: {sequence_run_id}"
+        )
+
+    orcabus_id = results[0].get("orcabusId")
+    if not orcabus_id:
+        raise Http404(
+            f"Sequence service response missing 'orcabusId' for sequenceRunId: {sequence_run_id}"
+        )
+
+    external_entity = ExternalEntity.objects.create(
+        orcabus_id=orcabus_id,
+        prefix=orcabus_id.split(".")[0] if "." in orcabus_id else "",
+        type="sequence_run",
+        service_name="sequence",
+        alias=sequence_run_id,
+    )
+    logger.info(f"Created sequence run external entity: {sequence_run_id}")
+    return external_entity
+
+
 def get_or_create_external_entity(external_entity_orcabus_id: str) -> ExternalEntity:
     """
-    Get or create external entity by orcabus_id
+    Get or create external entity by orcabus_id.
 
-    it will get the external entity if it exists, otherwise it will create a new one with the given orcabus_id.
-    The creation is only lookup to workflow_run (workflow service) and library (metadata service), if a prefix is found in the orcabus_id, it will only lookup to the corresponding service.
+    Creates the entity by looking it up in the appropriate service based on the orcabus_id prefix:
+      prefix wfr. -> workflow run (workflow service)
+      prefix lib. -> library (metadata service)
 
-    prefix wfr. -> workflow run
-    prefix lib. -> library
+    For sequence runs, use get_or_create_sequence_run_entity() instead.
     """
     try:
         external_entity = ExternalEntity.objects.get(

--- a/case-manager/app/tests/test_handler_sequence_run_linking.py
+++ b/case-manager/app/tests/test_handler_sequence_run_linking.py
@@ -1,0 +1,349 @@
+import logging
+from unittest.mock import patch, MagicMock
+
+from rest_framework.exceptions import ValidationError as DjangoValidationError
+from django.db import IntegrityError
+from django.http import Http404
+from django.test import TestCase
+
+from app.models import ExternalEntity, State
+from app.models.case import CaseExternalEntityLink
+from app.models.state import CaseStatus
+from app.tests.factories import CaseFactory, UserFactory
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Fixed test IDs — fake values, same format as real OrcaBus IDs
+# ---------------------------------------------------------------------------
+
+SEQUENCE_RUN_ORCABUS_ID = "seq.01ARZ3NDEKTSV4RRFFQ69G5010"
+SEQUENCE_RUN_ID = "r.uY6hEBUmv5x5XUDhkNVxtY"
+LIBRARY_ID_1 = "L0000001"
+LIBRARY_ID_2 = "L0000002"
+LIBRARY_ORCABUS_ID_1 = "lib.01ARZ3NDEKTSV4RRFFQ69G5011"
+LIBRARY_ORCABUS_ID_2 = "lib.01ARZ3NDEKTSV4RRFFQ69G5012"
+CASE_REQUEST_FORM_ID = "case-test-seq-001"
+
+
+def make_event(
+    sequence_run_id: str = SEQUENCE_RUN_ID,
+    linked_libraries: list | None = None,
+) -> dict:
+    """Build a minimal SequenceRunStateChange EventBridge event."""
+    if linked_libraries is None:
+        linked_libraries = [LIBRARY_ID_1, LIBRARY_ID_2]
+    return {
+        "detail-type": "SequenceRunStateChange",
+        "source": "orcabus.sequencerunmanager",
+        "detail": {
+            "sequenceRunId": sequence_run_id,
+            "instrumentRunId": "240229_A01052_0172_BHVLMJDMXY",
+            "timeStamp": "2024-02-29T10:00:00Z",
+            "linkedLibraries": linked_libraries,
+        },
+    }
+
+
+class SequenceRunLinkingHandlerTest(TestCase):
+    """
+    python manage.py test app.tests.test_handler_sequence_run_linking
+    """
+
+    def _create_seq_run_entity(self):
+        obj, _ = ExternalEntity.objects.get_or_create(
+            orcabus_id=SEQUENCE_RUN_ORCABUS_ID,
+            prefix="seq",
+            type="sequence_run",
+            service_name="sequence",
+            alias=SEQUENCE_RUN_ID,
+        )
+        return obj
+
+    def setUp(self):
+        self.case = CaseFactory(request_form_id=CASE_REQUEST_FORM_ID)
+        # Create library entity and link it to the case (library is matched by alias)
+        self.library_entity = ExternalEntity.objects.create(
+            orcabus_id=LIBRARY_ORCABUS_ID_1,
+            prefix="lib",
+            type="library",
+            service_name="metadata",
+            alias=LIBRARY_ID_1,
+        )
+        CaseExternalEntityLink.objects.create(
+            case=self.case, external_entity=self.library_entity
+        )
+
+    # ------------------------------------------------------------------
+    # Multi-library, same case — deduplicated to a single link
+    # ------------------------------------------------------------------
+
+    @patch("handler.sequence_run_linking.get_or_create_sequence_run_entity")
+    @patch("handler.sequence_run_linking.link_case_to_external_entity_and_emit")
+    def test_multiple_libraries_same_case_links_once(self, mock_link, mock_get_entity):
+        """
+        When both libraries in the event are linked to the same case,
+        the sequence run should be linked to that case exactly once (deduplicated).
+        """
+        from handler.sequence_run_linking import handler
+
+        # Link a second library to the same case
+        library_entity_2 = ExternalEntity.objects.create(
+            orcabus_id=LIBRARY_ORCABUS_ID_2,
+            prefix="lib",
+            type="library",
+            service_name="metadata",
+            alias=LIBRARY_ID_2,
+        )
+        CaseExternalEntityLink.objects.create(
+            case=self.case, external_entity=library_entity_2
+        )
+
+        mock_seq_entity = MagicMock()
+        mock_get_entity.return_value = mock_seq_entity
+        mock_link.return_value = MagicMock()
+
+        handler(make_event(), {})  # event carries both LIBRARY_ID_1 and LIBRARY_ID_2
+
+        mock_get_entity.assert_called_once_with(SEQUENCE_RUN_ID)
+        # Both libraries point to the same case → link must be called exactly once
+        mock_link.assert_called_once_with(
+            self.case, mock_seq_entity, history_user="system"
+        )
+
+    # ------------------------------------------------------------------
+    # Multi-library, different cases — all cases linked
+    # ------------------------------------------------------------------
+
+    @patch("handler.sequence_run_linking.get_or_create_sequence_run_entity")
+    def test_multiple_libraries_different_cases_links_all(self, mock_get_entity):
+        """
+        When each library is linked to a different case, the sequence run should be
+        linked to every matched case. Verified against the real DB (no mock on link).
+        """
+        from handler.sequence_run_linking import handler
+
+        case_2 = CaseFactory(request_form_id="case-test-seq-002")
+        library_entity_2 = ExternalEntity.objects.create(
+            orcabus_id=LIBRARY_ORCABUS_ID_2,
+            prefix="lib",
+            type="library",
+            service_name="metadata",
+            alias=LIBRARY_ID_2,
+        )
+        CaseExternalEntityLink.objects.create(
+            case=case_2, external_entity=library_entity_2
+        )
+
+        seq_entity = self._create_seq_run_entity()
+        mock_get_entity.return_value = seq_entity
+
+        handler(make_event(), {})
+
+        # get_or_create called once — same entity shared across all case links
+        mock_get_entity.assert_called_once_with(SEQUENCE_RUN_ID)
+
+        # Both cases must now be linked to the sequence run in the DB
+        self.assertTrue(
+            CaseExternalEntityLink.objects.filter(
+                case=self.case, external_entity=seq_entity
+            ).exists(),
+            "case 1 should be linked to the sequence run",
+        )
+        self.assertTrue(
+            CaseExternalEntityLink.objects.filter(
+                case=case_2, external_entity=seq_entity
+            ).exists(),
+            "case 2 should be linked to the sequence run",
+        )
+
+    # ------------------------------------------------------------------
+    # Sequence run entity does not yet exist (first time seen)
+    # ------------------------------------------------------------------
+
+    @patch("handler.sequence_run_linking.get_or_create_sequence_run_entity")
+    def test_sequence_run_entity_created_when_not_yet_existing(self, mock_get_entity):
+        """
+        When the sequence run ExternalEntity does not exist yet,
+        get_or_create_sequence_run_entity creates it; the link is still persisted.
+        """
+        from handler.sequence_run_linking import handler
+
+        # Confirm the entity doesn't exist yet
+        self.assertFalse(
+            ExternalEntity.objects.filter(
+                alias=SEQUENCE_RUN_ID, type="sequence_run"
+            ).exists()
+        )
+
+        # Simulate the service creating the entity on first call
+        new_seq_entity = self._create_seq_run_entity()
+        mock_get_entity.return_value = new_seq_entity
+
+        handler(make_event(linked_libraries=[LIBRARY_ID_1]), {})
+
+        mock_get_entity.assert_called_once_with(SEQUENCE_RUN_ID)
+        self.assertTrue(
+            CaseExternalEntityLink.objects.filter(
+                case=self.case, external_entity=new_seq_entity
+            ).exists(),
+            "case should be linked to the newly created sequence run entity",
+        )
+
+    # ------------------------------------------------------------------
+    # No matching case
+    # ------------------------------------------------------------------
+
+    @patch("handler.sequence_run_linking.get_or_create_sequence_run_entity")
+    @patch("handler.sequence_run_linking.link_case_to_external_entity_and_emit")
+    def test_no_case_for_any_library_skips_silently(self, mock_link, mock_get_entity):
+        """No case is linked to any library → warn and return without linking."""
+        from handler.sequence_run_linking import handler
+
+        event = make_event(linked_libraries=["L9999999", "L8888888"])
+        handler(event, {})
+
+        mock_get_entity.assert_not_called()
+        mock_link.assert_not_called()
+
+    # ------------------------------------------------------------------
+    # Missing event fields
+    # ------------------------------------------------------------------
+
+    @patch("handler.sequence_run_linking.get_or_create_sequence_run_entity")
+    @patch("handler.sequence_run_linking.link_case_to_external_entity_and_emit")
+    def test_missing_sequence_run_id_returns_early(self, mock_link, mock_get_entity):
+        """Event with no sequenceRunId is silently skipped."""
+        from handler.sequence_run_linking import handler
+
+        event = {"detail": {"linkedLibraries": [LIBRARY_ID_1]}}
+        handler(event, {})
+
+        mock_get_entity.assert_not_called()
+        mock_link.assert_not_called()
+
+    @patch("handler.sequence_run_linking.get_or_create_sequence_run_entity")
+    @patch("handler.sequence_run_linking.link_case_to_external_entity_and_emit")
+    def test_missing_linked_libraries_returns_early(self, mock_link, mock_get_entity):
+        """Event with no linkedLibraries is silently skipped."""
+        from handler.sequence_run_linking import handler
+
+        event = {"detail": {"sequenceRunId": SEQUENCE_RUN_ID, "linkedLibraries": []}}
+        handler(event, {})
+
+        mock_get_entity.assert_not_called()
+        mock_link.assert_not_called()
+
+    # ------------------------------------------------------------------
+    # Idempotency
+    # ------------------------------------------------------------------
+
+    @patch("handler.sequence_run_linking.get_or_create_sequence_run_entity")
+    def test_redelivered_event_does_not_raise_on_existing_link(self, mock_get_entity):
+        """
+        EventBridge delivers events at-least-once, so the same event may be replayed
+        (e.g. after a Lambda retry). The handler is called twice with the same event:
+        - First call creates the link in the DB.
+        - Second call hits the unique constraint → IntegrityError, must be swallowed.
+        """
+        from handler.sequence_run_linking import handler
+
+        seq_entity = self._create_seq_run_entity()
+        mock_get_entity.return_value = seq_entity
+
+        event = make_event(linked_libraries=[LIBRARY_ID_1])
+
+        handler(event, {})  # first invocation — creates the link
+        handler(event, {})  # second invocation (replay) — must NOT raise
+
+    # ------------------------------------------------------------------
+    # Http404 propagation (hard failure — Lambda should retry)
+    # ------------------------------------------------------------------
+
+    @patch("handler.sequence_run_linking.get_or_create_sequence_run_entity")
+    def test_http404_from_get_or_create_propagates(self, mock_get_entity):
+        """Http404 from get_or_create_sequence_run_entity is NOT caught — Lambda should retry."""
+        from handler.sequence_run_linking import handler
+
+        mock_get_entity.side_effect = Http404(
+            "sequence run not found in sequence service"
+        )
+
+        with self.assertRaises(Http404):
+            handler(make_event(linked_libraries=[LIBRARY_ID_1]), {})
+
+    # ------------------------------------------------------------------
+    # Locked / blocked case states
+    # ------------------------------------------------------------------
+
+    @patch("handler.sequence_run_linking.get_or_create_sequence_run_entity")
+    def test_blocked_case_states_skip_link(self, mock_get_entity):
+        """ValidationError is caught for all blocked statuses; no link is created."""
+        from handler.sequence_run_linking import handler
+
+        user = UserFactory()
+        blocked_statuses = [
+            CaseStatus.LOCKED,
+            CaseStatus.COMPLETED,
+            CaseStatus.ARCHIVED,
+        ]
+
+        for status in blocked_statuses:
+            with self.subTest(status=status):
+                State.objects.create(case=self.case, status=status, created_by=user)
+                mock_get_entity.return_value = self._create_seq_run_entity()
+
+                handler(
+                    make_event(linked_libraries=[LIBRARY_ID_1]), {}
+                )  # should NOT raise
+
+                self.assertFalse(
+                    CaseExternalEntityLink.objects.filter(
+                        case=self.case,
+                        external_entity__orcabus_id=SEQUENCE_RUN_ORCABUS_ID,
+                    ).exists(),
+                    msg=f"Expected no link for status '{status}'",
+                )
+
+    # ------------------------------------------------------------------
+    # Second library matched (first not linked to any case)
+    # ------------------------------------------------------------------
+
+    @patch("handler.sequence_run_linking.get_or_create_sequence_run_entity")
+    @patch("handler.sequence_run_linking.link_case_to_external_entity_and_emit")
+    def test_matches_second_library_when_first_not_linked(
+        self, mock_link, mock_get_entity
+    ):
+        """
+        The event contains two libraries. LIBRARY_ID_1 exists as an entity but has no
+        case linked to it (its CaseExternalEntityLink was removed). LIBRARY_ID_2 is
+        linked to self.case. The handler iterates all libraries independently, so the
+        case is still found and linked via LIBRARY_ID_2.
+        """
+        from handler.sequence_run_linking import handler
+
+        # Remove the link for LIBRARY_ID_1, link LIBRARY_ID_2 to the case instead
+        CaseExternalEntityLink.objects.filter(
+            external_entity=self.library_entity
+        ).delete()
+        library_entity_2 = ExternalEntity.objects.create(
+            orcabus_id=LIBRARY_ORCABUS_ID_2,
+            prefix="lib",
+            type="library",
+            service_name="metadata",
+            alias=LIBRARY_ID_2,
+        )
+        CaseExternalEntityLink.objects.create(
+            case=self.case, external_entity=library_entity_2
+        )
+
+        mock_seq_entity = MagicMock()
+        mock_get_entity.return_value = mock_seq_entity
+        mock_link.return_value = MagicMock()
+
+        handler(make_event(), {})  # event carries both LIBRARY_ID_1 and LIBRARY_ID_2
+
+        mock_get_entity.assert_called_once_with(SEQUENCE_RUN_ID)
+        mock_link.assert_called_once_with(
+            self.case, mock_seq_entity, history_user="system"
+        )

--- a/case-manager/app/tests/test_handler_workflow_run_linking.py
+++ b/case-manager/app/tests/test_handler_workflow_run_linking.py
@@ -222,6 +222,85 @@ class WorkflowRunLinkingHandlerTest(TestCase):
                     msg=f"Expected no link for status '{status}'",
                 )
 
+    # ------------------------------------------------------------------
+    # Multi-library / multi-case linking
+    # ------------------------------------------------------------------
+
+    @patch("handler.workflow_run_linking.get_or_create_external_entity")
+    @patch("handler.workflow_run_linking.link_case_to_external_entity_and_emit")
+    def test_multiple_libraries_same_case_links_once(self, mock_link, mock_get_entity):
+        """
+        When both libraries in the event are linked to the same case,
+        the workflow run should be linked to that case exactly once (deduplicated).
+        """
+        from handler.workflow_run_linking import handler
+
+        # Link the second library to the same case
+        library_entity_2 = ExternalEntity.objects.create(
+            orcabus_id=LIBRARY_ORCABUS_ID_2,
+            prefix="lib",
+            type="library",
+            service_name="metadata",
+            alias=LIBRARY_ID_2,
+        )
+        CaseExternalEntityLink.objects.create(
+            case=self.case, external_entity=library_entity_2
+        )
+
+        mock_wfr_entity = MagicMock()
+        mock_get_entity.return_value = mock_wfr_entity
+        mock_link.return_value = MagicMock()
+
+        handler(make_event(), {})
+
+        mock_get_entity.assert_called_once_with(WORKFLOW_RUN_ORCABUS_ID)
+        # Even though two libraries matched, both point to the same case → one link call
+        mock_link.assert_called_once_with(
+            self.case, mock_wfr_entity, history_user="system"
+        )
+
+    @patch("handler.workflow_run_linking.get_or_create_external_entity")
+    def test_multiple_libraries_different_cases_links_all(self, mock_get_entity):
+        """
+        When each library is linked to a different case, the workflow run should be
+        linked to every matched case. Verified against the real DB (no mock on link).
+        """
+        from handler.workflow_run_linking import handler
+
+        case_2 = CaseFactory(request_form_id="case-test-wfr-002")
+        library_entity_2 = ExternalEntity.objects.create(
+            orcabus_id=LIBRARY_ORCABUS_ID_2,
+            prefix="lib",
+            type="library",
+            service_name="metadata",
+            alias=LIBRARY_ID_2,
+        )
+        CaseExternalEntityLink.objects.create(
+            case=case_2, external_entity=library_entity_2
+        )
+
+        wfr_entity = self._create_wfr_entity()
+        mock_get_entity.return_value = wfr_entity
+
+        handler(make_event(), {})
+
+        # get_or_create called once — same entity shared across all case links
+        mock_get_entity.assert_called_once_with(WORKFLOW_RUN_ORCABUS_ID)
+
+        # Both cases must now be linked to the workflow run in the DB
+        self.assertTrue(
+            CaseExternalEntityLink.objects.filter(
+                case=self.case, external_entity=wfr_entity
+            ).exists(),
+            "case 1 should be linked to the workflow run",
+        )
+        self.assertTrue(
+            CaseExternalEntityLink.objects.filter(
+                case=case_2, external_entity=wfr_entity
+            ).exists(),
+            "case 2 should be linked to the workflow run",
+        )
+
     def test_model_raises_validation_error_directly_for_locked_case(self):
         """CaseExternalEntityLink.save() itself raises ValidationError — model-level enforcement."""
         user = UserFactory()

--- a/case-manager/app/viewsets/case.py
+++ b/case-manager/app/viewsets/case.py
@@ -1,3 +1,4 @@
+from django.db import IntegrityError
 from drf_spectacular.utils import extend_schema
 from rest_framework import serializers
 from rest_framework.decorators import action
@@ -27,7 +28,9 @@ from ..service.case import (
     unlink_case_to_external_entity_and_emit,
     get_case_activity,
 )
-from ..service.external_entity import get_or_create_external_entity
+from ..service.external_entity import (
+    get_or_create_external_entity,
+)
 from ..service.redcap_import import (
     get_redcap_record_by_filter,
     upsert_case_from_redcap_record,
@@ -56,9 +59,18 @@ class CaseLinkMixin:
         external_entity = get_or_create_external_entity(
             serializer.validated_data["external_entity"]
         )
-        link = link_case_to_external_entity_and_emit(
-            case, external_entity, get_email_from_jwt(request)
-        )
+        try:
+            link = link_case_to_external_entity_and_emit(
+                case, external_entity, get_email_from_jwt(request)
+            )
+        except IntegrityError:
+            return Response(
+                {
+                    "detail": f"A link between case '{case.orcabus_id}' and external entity "
+                    f"'{external_entity.orcabus_id}' already exists."
+                },
+                status=status.HTTP_409_CONFLICT,
+            )
         return Response(CaseExternalEntityLinkCreateSerializer(link).data)
 
     @extend_schema(

--- a/case-manager/handler/sequence_run_linking.py
+++ b/case-manager/handler/sequence_run_linking.py
@@ -1,0 +1,110 @@
+import os
+import logging
+import django
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "app.settings.base")
+django.setup()
+
+from django.db import IntegrityError
+from rest_framework.exceptions import ValidationError
+
+from app.service.external_entity import get_or_create_sequence_run_entity
+from app.service.case import link_case_to_external_entity_and_emit
+from app.models import CaseExternalEntityLink
+from app.serializers.case import CaseExternalEntityLinkSerializer
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+def handler(event, context):
+    """
+    Lambda handler that links a sequence run to a case via an EventBridge
+    SequenceRunStateChange event.
+
+    The handler inspects the libraries attached to the sequence run and looks for a case
+    that already has one of those libraries linked as an external entity. If found, the
+    sequence run itself is also linked to that case as an external entity.
+
+    Expected event detail shape:
+        {
+            "instrumentRunId": "...",
+            "sequenceRunId": "r.<ulid>",
+            "timeStamp": "...",
+            "linkedLibraries": ["L0000001", "L0000002", ...]
+        }
+    """
+    logger.info(f"Processing event: {event}")
+
+    detail = event.get("detail", {})
+
+    sequence_run_id = detail.get("sequenceRunId")
+    linked_libraries = detail.get("linkedLibraries", [])
+
+    if not sequence_run_id:
+        logger.warning("Skipping event: no 'sequenceRunId' found in detail.")
+        return
+
+    if not linked_libraries:
+        logger.warning(
+            f"Skipping event: no libraries found in detail for sequence run '{sequence_run_id}'."
+        )
+        return
+
+    # Find all cases linked to any of the libraries (deduplicated by case id).
+    # linkedLibraries contains plain library IDs (e.g. "L2600353") which are
+    # stored as the 'alias' on library ExternalEntity records.
+    case_to_library_map = {}  # case_orcabus_id -> (case, matched_library_id)
+    for library_id in linked_libraries:
+        try:
+            links = CaseExternalEntityLink.objects.select_related("case").filter(
+                external_entity__alias=library_id,
+                external_entity__type="library",
+            )
+            for link in links:
+                case = link.case
+                if case.orcabus_id not in case_to_library_map:
+                    case_to_library_map[case.orcabus_id] = (case, library_id)
+                    logger.info(
+                        f"Found case '{case.orcabus_id}' via library '{library_id}'."
+                    )
+        except CaseExternalEntityLink.DoesNotExist:
+            logger.debug(f"No case linked to library '{library_id}', trying next.")
+            continue
+
+    if not case_to_library_map:
+        logger.warning(
+            f"No case found linked to any of the libraries for sequence run "
+            f"'{sequence_run_id}'. Libraries checked: {linked_libraries}"
+        )
+        return
+
+    # Get or create the sequence run as an external entity.
+    # The sequenceRunId is NOT the orcabus_id — get_or_create_sequence_run_entity
+    # first queries the sequence service to resolve the real orcabusId.
+    # Http404 is intentionally not caught here: if the sequence run is not found in the
+    # sequence service, we treat it as a hard failure so the Lambda retries the event.
+    sequence_run_entity = get_or_create_sequence_run_entity(sequence_run_id)
+
+    for case_orcabus_id, (case, matched_library_id) in case_to_library_map.items():
+        try:
+            link = link_case_to_external_entity_and_emit(
+                case, sequence_run_entity, history_user="system"
+            )
+            logger.info(
+                f"Successfully linked sequence run '{sequence_run_id}' to case '{case.orcabus_id}' "
+                f"(matched via library '{matched_library_id}')."
+            )
+            logger.info(f"Link data: {CaseExternalEntityLinkSerializer(link).data}")
+
+        except ValidationError as e:
+            # Case is locked / completed / archived — blocked at the model level.
+            # Log a warning and continue to the next case; no retry needed.
+            logger.warning(
+                f"Skipping sequence run link for '{sequence_run_id}' to case '{case.orcabus_id}': {e.detail}"
+            )
+
+        except IntegrityError:
+            logger.warning(
+                f"Sequence run '{sequence_run_id}' is already linked to case '{case.orcabus_id}', skipping."
+            )

--- a/case-manager/handler/sequence_run_linking.py
+++ b/case-manager/handler/sequence_run_linking.py
@@ -29,7 +29,7 @@ def handler(event, context):
     Expected event detail shape:
         {
             "instrumentRunId": "...",
-            "sequenceRunId": "r.<ulid>",
+            "sequenceRunId": "r.xxx",
             "timeStamp": "...",
             "linkedLibraries": ["L0000001", "L0000002", ...]
         }

--- a/case-manager/handler/workflow_run_linking.py
+++ b/case-manager/handler/workflow_run_linking.py
@@ -42,29 +42,29 @@ def handler(event, context):
         )
         return
 
-    # Find a case linked to any of the libraries
-    case = None
-    matched_library_id = None
+    # Find all cases linked to any of the libraries (deduplicated by case id)
+    case_to_library_map = {}  # case_orcabus_id -> (case, matched_library_id)
     for lib in libraries:
         lib_orcabus_id = lib.get("orcabusId")
         if not lib_orcabus_id:
             continue
 
         try:
-            link = CaseExternalEntityLink.objects.select_related("case").get(
+            links = CaseExternalEntityLink.objects.select_related("case").filter(
                 external_entity__orcabus_id=lib_orcabus_id
             )
-            case = link.case
-            matched_library_id = lib_orcabus_id
-            logger.info(
-                f"Found case '{case.orcabus_id}' via library '{lib_orcabus_id}'."
-            )
-            break
+            for link in links:
+                case = link.case
+                if case.orcabus_id not in case_to_library_map:
+                    case_to_library_map[case.orcabus_id] = (case, lib_orcabus_id)
+                    logger.info(
+                        f"Found case '{case.orcabus_id}' via library '{lib_orcabus_id}'."
+                    )
         except CaseExternalEntityLink.DoesNotExist:
             logger.debug(f"No case linked to library '{lib_orcabus_id}', trying next.")
             continue
 
-    if case is None:
+    if not case_to_library_map:
         logger.warning(
             f"No case found linked to any of the libraries for workflow run "
             f"'{workflow_run_orcabus_id}'. Libraries checked: "
@@ -77,24 +77,25 @@ def handler(event, context):
     # workflow service, we treat it as a hard failure so the Lambda retries the event.
     workflow_run_entity = get_or_create_external_entity(workflow_run_orcabus_id)
 
-    try:
-        link = link_case_to_external_entity_and_emit(
-            case, workflow_run_entity, history_user="system"
-        )
-        logger.info(
-            f"Successfully linked workflow run '{workflow_run_orcabus_id}' to case '{case.orcabus_id}' "
-            f"(matched via library '{matched_library_id}')."
-        )
-        logger.info(f"Link data: {CaseExternalEntityLinkSerializer(link).data}")
+    for case_orcabus_id, (case, matched_library_id) in case_to_library_map.items():
+        try:
+            link = link_case_to_external_entity_and_emit(
+                case, workflow_run_entity, history_user="system"
+            )
+            logger.info(
+                f"Successfully linked workflow run '{workflow_run_orcabus_id}' to case '{case.orcabus_id}' "
+                f"(matched via library '{matched_library_id}')."
+            )
+            logger.info(f"Link data: {CaseExternalEntityLinkSerializer(link).data}")
 
-    except ValidationError as e:
-        # Case is locked / completed / archived — blocked at the model level.
-        # Log a warning and return cleanly; no retry needed.
-        logger.warning(
-            f"Skipping workflow run link for '{workflow_run_orcabus_id}': {e.detail}"
-        )
+        except ValidationError as e:
+            # Case is locked / completed / archived — blocked at the model level.
+            # Log a warning and continue to the next case; no retry needed.
+            logger.warning(
+                f"Skipping workflow run link for '{workflow_run_orcabus_id}' to case '{case.orcabus_id}': {e.detail}"
+            )
 
-    except IntegrityError:
-        logger.warning(
-            f"Workflow run '{workflow_run_orcabus_id}' is already linked to case '{case.orcabus_id}', skipping."
-        )
+        except IntegrityError:
+            logger.warning(
+                f"Workflow run '{workflow_run_orcabus_id}' is already linked to case '{case.orcabus_id}', skipping."
+            )

--- a/infrastructure/stage/construct/lambda-sequence-run-linking/index.ts
+++ b/infrastructure/stage/construct/lambda-sequence-run-linking/index.ts
@@ -1,0 +1,72 @@
+import { Construct } from 'constructs';
+import { PythonFunction, PythonFunctionProps } from '@aws-cdk/aws-lambda-python-alpha';
+import { Duration } from 'aws-cdk-lib';
+import { ManagedPolicy } from 'aws-cdk-lib/aws-iam';
+import { formatRdsPolicyName } from '@orcabus/platform-cdk-constructs/shared-config/database';
+import { LambdaFunction } from 'aws-cdk-lib/aws-events-targets';
+import { EventBus, Rule } from 'aws-cdk-lib/aws-events';
+import { EVENT_BUS_NAME } from '@orcabus/platform-cdk-constructs/shared-config/event-bridge';
+import { Secret } from 'aws-cdk-lib/aws-secretsmanager';
+import { JWT_SECRET_NAME } from '@orcabus/platform-cdk-constructs/shared-config/secrets';
+import { StringParameter } from 'aws-cdk-lib/aws-ssm';
+
+type SequenceRunEntityLinkLambdaProps = {
+  /**
+   * The basic common lambda properties that it should inherit from
+   */
+  basicLambdaConfig: PythonFunctionProps;
+};
+
+/**
+ * Lambda triggered by EventBridge on SequenceRunStateChange events
+ */
+export class LambdaSequenceRunEntityLinkConstruct extends Construct {
+  readonly lambda: PythonFunction;
+  constructor(scope: Construct, id: string, props: SequenceRunEntityLinkLambdaProps) {
+    super(scope, id);
+
+    this.lambda = new PythonFunction(this, 'CaseSequenceRunLinkLambda', {
+      ...props.basicLambdaConfig,
+      index: 'handler/sequence_run_linking.py',
+      handler: 'handler',
+      timeout: Duration.minutes(15),
+      // Not using environment here to prevent overriding from the basicLambdaConfig EnvVar
+    });
+    this.lambda.role?.addManagedPolicy(
+      ManagedPolicy.fromManagedPolicyName(
+        this,
+        'OrcabusRdsConnectPolicy',
+        formatRdsPolicyName('case_manager')
+      )
+    );
+
+    // pass the domain name for other services
+    const hostedZoneName = StringParameter.valueFromLookup(this, '/hosted_zone/umccr/name');
+    this.lambda.addEnvironment('HOSTED_ZONE_NAME', hostedZoneName);
+
+    // allow lambda to retrieve the service user JWT
+    const serviceUserJwtSecret = Secret.fromSecretNameV2(
+      this,
+      'serviceUserJwtSecret',
+      JWT_SECRET_NAME
+    );
+    this.lambda.addEnvironment('ORCABUS_SERVICE_JWT_SECRET_ARN', serviceUserJwtSecret.secretArn);
+    serviceUserJwtSecret.grantRead(this.lambda);
+
+    const orcabusEventBus = EventBus.fromEventBusName(this, 'EventBus', EVENT_BUS_NAME);
+    orcabusEventBus.grantPutEventsTo(this.lambda);
+    this.lambda.addEnvironment('EVENT_BUS_NAME', EVENT_BUS_NAME);
+
+    // Add EventBridge rule to trigger Lambda on SequenceRunStateChange events to link with cases
+    const sequenceRunLinkLambdaEventTarget = new LambdaFunction(this.lambda);
+    new Rule(this, 'SequenceRunLibraryEntityLinkLambdaRule', {
+      eventBus: orcabusEventBus,
+      description:
+        'Rule to trigger Lambda on SequenceRunLibraryLinkingChange events to link with cases',
+      eventPattern: {
+        detailType: ['SequenceRunLibraryLinkingChange'],
+      },
+      targets: [sequenceRunLinkLambdaEventTarget],
+    });
+  }
+}

--- a/infrastructure/stage/construct/lambda-workflow-run-linking/index.ts
+++ b/infrastructure/stage/construct/lambda-workflow-run-linking/index.ts
@@ -12,7 +12,7 @@ import { StringParameter } from 'aws-cdk-lib/aws-ssm';
 
 const WGS_WORKFLOW = ['sash', 'tumor-normal', 'dragen-wgts-dna'];
 const WTS_WORKFLOW = ['rnasum', 'wts', 'dragen-wgts-rna'];
-const CTTSO_WORKFLOW = ['dragen-tso500-ctdna', 'cttsov2'];
+const CTTSO_WORKFLOW = ['dragen-tso500-ctdna', 'cttsov2', 'pieriandx-tso500-ctdna'];
 const SUPPORTED_WORKFLOWS = [...WGS_WORKFLOW, ...WTS_WORKFLOW, ...CTTSO_WORKFLOW];
 
 type WorkflowRunEntityLinkLambdaProps = {

--- a/infrastructure/stage/construct/lambda-workflow-run-linking/index.ts
+++ b/infrastructure/stage/construct/lambda-workflow-run-linking/index.ts
@@ -66,6 +66,11 @@ export class LambdaWorkflowRunEntityLinkConstruct extends Construct {
         detailType: ['WorkflowRunStateChange'],
         detail: {
           status: ['READY'],
+          workflow: {
+            name: [
+              { 'anything-but': { 'equals-ignore-case': ['bclconvert', 'bclconvert-interop-qc'] } },
+            ],
+          },
         },
       },
       targets: [workflowRunLinkLambdaEventTarget],

--- a/infrastructure/stage/construct/lambda-workflow-run-linking/index.ts
+++ b/infrastructure/stage/construct/lambda-workflow-run-linking/index.ts
@@ -10,6 +10,11 @@ import { Secret } from 'aws-cdk-lib/aws-secretsmanager';
 import { JWT_SECRET_NAME } from '@orcabus/platform-cdk-constructs/shared-config/secrets';
 import { StringParameter } from 'aws-cdk-lib/aws-ssm';
 
+const WGS_WORKFLOW = ['sash', 'tumor-normal', 'dragen-wgts-dna'];
+const WTS_WORKFLOW = ['rnasum', 'wts', 'dragen-wgts-rna'];
+const CTTSO_WORKFLOW = ['dragen-tso500-ctdna', 'cttsov2'];
+const SUPPORTED_WORKFLOWS = [...WGS_WORKFLOW, ...WTS_WORKFLOW, ...CTTSO_WORKFLOW];
+
 type WorkflowRunEntityLinkLambdaProps = {
   /**
    * The basic common lambda properties that it should inherit from
@@ -67,9 +72,7 @@ export class LambdaWorkflowRunEntityLinkConstruct extends Construct {
         detail: {
           status: ['READY'],
           workflow: {
-            name: [
-              { 'anything-but': { 'equals-ignore-case': ['bclconvert', 'bclconvert-interop-qc'] } },
-            ],
+            name: SUPPORTED_WORKFLOWS,
           },
         },
       },

--- a/infrastructure/stage/stack.ts
+++ b/infrastructure/stage/stack.ts
@@ -16,6 +16,7 @@ import { EventSchemaConstruct } from './construct/event-schema';
 import { LambdaRedCapImportConstruct } from './construct/lambda-redcap-import';
 import { LambdaMetadataEntityLinkConstruct } from './construct/lambda-metadata-linking';
 import { LambdaWorkflowRunEntityLinkConstruct } from './construct/lambda-workflow-run-linking';
+import { LambdaSequenceRunEntityLinkConstruct } from './construct/lambda-sequence-run-linking';
 
 export type CaseManagerStackProps = {
   /**
@@ -115,6 +116,10 @@ export class CaseManagerStack extends Stack {
     });
 
     new LambdaWorkflowRunEntityLinkConstruct(this, 'LambdaWorkflowRunEntityLink', {
+      basicLambdaConfig: basicLambdaConfig,
+    });
+
+    new LambdaSequenceRunEntityLinkConstruct(this, 'LambdaSequenceRunEntityLink', {
       basicLambdaConfig: basicLambdaConfig,
     });
   }


### PR DESCRIPTION
- Add EventBridge rules to only whitelist `["sash", "tumor-normal", "dragen-wgts-dna", "rnasum", "wts", "dragen-wgts-rna", "dragen-tso500-ctdna", "cttsov2", "pieriandx-tso500-ctdna"]` workflow run matches.
- Ensure workflow runs associated with multiple libraries are linked to all matching cases for those libraries.
- Add rules and a handler to link sequence_run records to their corresponding cases through all of the associated libraries.